### PR TITLE
Added periodic-table related functions

### DIFF
--- a/chemyst/periodic_table.py
+++ b/chemyst/periodic_table.py
@@ -82,3 +82,34 @@ def period_number(z:int) -> int :
             ultimate_shell = int(i[0])
 
     return ultimate_shell
+
+# def group_number(z:int) -> int:
+#     """
+#     Returns the group number of an element corresponding to the Modern Periodic Table.
+#     """
+#     _check_atomic_number(z)
+
+#     config = electronic_config(z).split(" ")
+
+#     last_subshell_no = config[-1][0]
+#     last_subshell = config[-1][1]
+#     valence_electrons = 0
+
+#     for i in config:
+#         if last_subshell_no == i[0]:
+#             valence_electrons += int(i[2:])
+
+#     if last_subshell == "S":
+#         return valence_electrons
+
+#     elif last_subshell == "P":
+#         return valence_electrons + 10
+
+#     elif last_subshell == "D":
+#         return "D block" 
+
+#     elif last_subshell == "F":
+#         return 3
+
+#     else:
+#         print("Invalid subshell")

--- a/chemyst/periodic_table.py
+++ b/chemyst/periodic_table.py
@@ -1,0 +1,84 @@
+# periodic table related functions
+
+class InvalidAtomicNumber(Exception):
+    """
+    Error class for invalid atomic numbers.
+    """
+    pass
+
+def _check_atomic_number(z:int) -> None:
+    """
+    Checks if the atomic number provided is valid or not.
+    """
+    if z <= 0:
+        raise InvalidAtomicNumber("Atomic number (Z) of an element cant be zero or less than zero.")
+
+    elif z > 118:
+        raise InvalidAtomicNumber("Atomic number (Z) of an element cant be greater than 118.")
+
+
+def electronic_config(z:int) -> str:
+    """
+    Returns the electronic configuration of an element corresponding to the Modern Periodic Table in string format.
+    """
+    _check_atomic_number(z)
+
+    temp = z
+    series = ['1S', '2S', '2P', '3S', '3P', '4S', '3D', '4P', '5S', '4D', '5P', '6S', '4F', '5D', '6P', '7S', '5F', '6D', '7P']
+
+    result = ""
+
+    for shell in series:
+        if temp <= 0:
+            break
+
+        if shell.endswith("S"):
+            if temp < 2:
+                result += f"{shell}{temp} "
+                temp -= temp
+            else:
+                result += f"{shell}2 "
+                temp -= 2
+
+        elif shell.endswith("P"):
+            if temp < 6:
+                result += f"{shell}{temp} "
+                temp -= temp
+            else:
+                result += f"{shell}6 "
+                temp -= 6
+
+        elif shell.endswith("D"):
+            if temp < 10:
+                result += f"{shell}{temp} "
+                temp -= temp
+            else:
+                result += f"{shell}10 "
+                temp -= 10
+
+        elif shell.endswith("F"):
+            if temp < 14:
+                result += f"{shell}{temp} "
+                temp -= temp
+            else:
+                result += f"{shell}14 "
+                temp -= 14
+
+        else:
+            print("Invalid subshell!")
+
+    return result.rstrip()
+
+
+def period_number(z:int) -> int :
+    """
+    Returns the period number of an element corresponding to the Modern Periodic Table.
+    """
+    _check_atomic_number(z)
+    config = electronic_config(z).split(" ")
+    ultimate_shell = 1
+    for i in config:
+        if int(i[0]) > ultimate_shell:
+            ultimate_shell = int(i[0])
+
+    return ultimate_shell


### PR DESCRIPTION
closes https://github.com/mordy-python/chemyst/issues/1

I added the following public functions in the 'periodic_table.py':

- `electronic_config` which returns the electronic configuration of an element
- `period_number` which returns the period number of an element

I also worked on the `group_number` (it is commented out) and the function was returning correct values for S, P and F block elements but for the D block elements, the function was behaving absurdly.